### PR TITLE
Reference platform.h by ../src/platform.h - AIX is ignoring -I flags

### DIFF
--- a/perf/inproc_lat.cpp
+++ b/perf/inproc_lat.cpp
@@ -24,7 +24,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "platform.hpp"
+/* Just specifying platform.hpp and relying on -I flags doesn't work on AIX */
+#include "../src/platform.hpp"
 
 #if defined ZMQ_HAVE_WINDOWS
 #include <windows.h>

--- a/perf/inproc_thr.cpp
+++ b/perf/inproc_thr.cpp
@@ -26,7 +26,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "platform.hpp"
+/* Just specifying platform.hpp and relying on -I flags doesn't work on AIX */
+#include "../src/platform.hpp"
 
 #if defined ZMQ_HAVE_WINDOWS
 #include <windows.h>

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -22,7 +22,8 @@
 
 #include "../include/zmq.h"
 #include "../include/zmq_utils.h"
-#include "platform.hpp"
+/* Just specifying platform.hpp and relying on -I flags doesn't work on AIX */
+#include "../src/platform.hpp"
 
 #undef NDEBUG
 #include <time.h>


### PR DESCRIPTION
Fix the build on AIX - for some reason '-I../src' isn't working.
