### PR TITLE
Updated version number for 4.0.2

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -28,6 +28,16 @@
 #ifndef __ZMQ_H_INCLUDED__
 #define __ZMQ_H_INCLUDED__
 
+/*  Version macros for compile-time API version detection                     */
+#define ZMQ_VERSION_MAJOR 4
+#define ZMQ_VERSION_MINOR 0
+#define ZMQ_VERSION_PATCH 2
+
+#define ZMQ_MAKE_VERSION(major, minor, patch) \
+    ((major) * 10000 + (minor) * 100 + (patch))
+#define ZMQ_VERSION \
+    ZMQ_MAKE_VERSION(ZMQ_VERSION_MAJOR, ZMQ_VERSION_MINOR, ZMQ_VERSION_PATCH)
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -77,23 +87,6 @@ typedef unsigned __int8 uint8_t;
 #   include <stdint.h>
 #endif
 
-
-/******************************************************************************/
-/*  0MQ versioning support.                                                   */
-/******************************************************************************/
-
-/*  Version macros for compile-time API version detection                     */
-#define ZMQ_VERSION_MAJOR 4
-#define ZMQ_VERSION_MINOR 0
-#define ZMQ_VERSION_PATCH 1
-
-#define ZMQ_MAKE_VERSION(major, minor, patch) \
-    ((major) * 10000 + (minor) * 100 + (patch))
-#define ZMQ_VERSION \
-    ZMQ_MAKE_VERSION(ZMQ_VERSION_MAJOR, ZMQ_VERSION_MINOR, ZMQ_VERSION_PATCH)
-
-/*  Run-time API version detection                                            */
-ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
 
 /******************************************************************************/
 /*  0MQ errors.                                                               */
@@ -164,6 +157,9 @@ ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
 #define ENOCOMPATPROTO (ZMQ_HAUSNUMERO + 52)
 #define ETERM (ZMQ_HAUSNUMERO + 53)
 #define EMTHREAD (ZMQ_HAUSNUMERO + 54)
+
+/*  Run-time API version detection                                            */
+ZMQ_EXPORT void zmq_version (int *major, int *minor, int *patch);
 
 /*  This function retrieves the errno as it is known to 0MQ library. The goal */
 /*  of this function is to make the code 100% portable, including where 0MQ   */


### PR DESCRIPTION
- also moved macros to top of zmq.h for better visibility
