### PR TITLE
Fix hang on terminate when inproc is connected but never bound

### DIFF
--- a/src/ctx.cpp
+++ b/src/ctx.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2007-2013 Contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2014 Contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 
@@ -95,6 +95,14 @@ zmq::ctx_t::~ctx_t ()
 
 int zmq::ctx_t::terminate ()
 {
+    // Connect up any pending inproc connections, otherwise we will hang
+    pending_connections_t copy = pending_connections;
+    for (pending_connections_t::iterator p = copy.begin (); p != copy.end (); ++p) {
+        zmq::socket_base_t *s = create_socket (ZMQ_PAIR);
+        s->bind (p->first.c_str ());
+        s->close ();
+    }
+
     slot_sync.lock ();
     if (!starting) {
 

--- a/tests/test_inproc_connect.cpp
+++ b/tests/test_inproc_connect.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2007-2013 Contributors as noted in the AUTHORS file
+    Copyright (c) 2007-2014 Contributors as noted in the AUTHORS file
 
     This file is part of 0MQ.
 
@@ -324,6 +324,23 @@ void test_identity()
     assert (rc == 0);
 }
 
+void test_connect_only ()
+{
+    void *ctx = zmq_ctx_new ();
+    assert (ctx);
+
+    void *connectSocket = zmq_socket (ctx, ZMQ_PUSH);
+    assert (connectSocket);
+    int rc = zmq_connect (connectSocket, "inproc://a");
+    assert (rc == 0);
+
+    rc = zmq_close (connectSocket);
+    assert (rc == 0);
+
+    rc = zmq_ctx_term (ctx);
+    assert (rc == 0);
+}
+
 int main (void)
 {
     setup_test_environment();
@@ -334,6 +351,7 @@ int main (void)
     test_multiple_connects ();
     test_multiple_threads ();
     test_identity ();
+    test_connect_only ();
 
     return 0;
 }

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -22,7 +22,7 @@
 
 #include "../include/zmq.h"
 #include "../include/zmq_utils.h"
-#include "../src/platform.hpp"
+#include "platform.hpp"
 
 //  This defines the settle time used in tests; raise this if we
 //  get test failures on slower systems due to binds/connects not


### PR DESCRIPTION
Backported fix for #888
