### PR TITLE
Resolve issue #939

### DIFF
--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -307,7 +307,6 @@ int zmq::session_base_t::zap_connect ()
     zap_pipe->set_nodelay ();
     zap_pipe->set_event_sink (this);
 
-    new_pipes [1]->set_nodelay ();
     send_bind (peer.socket, new_pipes [1], false);
 
     //  Send empty identity if required by the peer.


### PR DESCRIPTION
This bug is caused by fq which can terminate pipe before sending all
frames of a message first. So sometimes two messages were mixed and this
confused ZAP handler.

This patch just modifies one pipe parameter so that socket consumes all
messages before dropping the pipe.
