### PR TITLE
backport stream socket empty frame fix

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -142,6 +142,8 @@ int zmq::stream_t::xsend (msg_t *msg_)
             current_out->terminate (false);
             int rc = msg_->close ();
             errno_assert (rc == 0);
+            rc = msg_->init ();
+            errno_assert (rc == 0);
             current_out = NULL;
             return 0;
         }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -41,7 +41,8 @@ noinst_PROGRAMS = test_system \
                   test_issue_566 \
                   test_abstract_ipc \
                   test_proxy_terminate \
-                  test_many_sockets
+                  test_many_sockets \
+                  test_stream_empty
 
 if !ON_MINGW
 noinst_PROGRAMS += test_shutdown_stress \
@@ -90,6 +91,7 @@ test_issue_566_SOURCES = test_issue_566.cpp
 test_abstract_ipc_SOURCES = test_abstract_ipc.cpp
 test_many_sockets_SOURCES = test_many_sockets.cpp
 test_proxy_terminate_SOURCES = test_proxy_terminate.cpp
+test_stream_empty_SOURCES = test_stream_empty.cpp
 if !ON_MINGW
 test_shutdown_stress_SOURCES = test_shutdown_stress.cpp
 test_pair_ipc_SOURCES = test_pair_ipc.cpp testutil.hpp

--- a/tests/test_stream_empty.cpp
+++ b/tests/test_stream_empty.cpp
@@ -1,0 +1,60 @@
+/*
+    Copyright (c) 2007-2015 Contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil.hpp"
+
+int main (void) {
+    setup_test_environment ();
+    void *ctx = zmq_ctx_new ();
+    assert (ctx);
+    
+    void *stream = zmq_socket (ctx, ZMQ_STREAM);
+    assert (stream);
+    void *dealer = zmq_socket (ctx, ZMQ_DEALER);
+    assert (dealer);
+    
+    int rc = zmq_bind (stream, "tcp://127.0.0.1:5555");
+    assert (rc >= 0);
+    rc = zmq_connect (dealer, "tcp://127.0.0.1:5555");
+    assert (rc >= 0);
+    zmq_send (dealer, "", 0, 0);
+    
+    zmq_msg_t ident, empty;
+    zmq_msg_init (&ident);
+    rc = zmq_msg_recv (&ident, stream, 0);
+    assert (rc >= 0);
+    rc = zmq_msg_init_data (&empty, (void *) "", 0, NULL, NULL);
+    assert (rc >= 0);
+    
+    rc = zmq_msg_send (&ident, stream, ZMQ_SNDMORE);
+    assert (rc >= 0);
+    rc = zmq_msg_close (&ident);
+    assert (rc >= 0);
+    
+    rc = zmq_msg_send (&empty, stream, 0);
+    assert (rc >= 0);
+    
+    //  This close used to fail with Bad Address
+    rc = zmq_msg_close (&empty);
+    assert (rc >= 0);
+    
+    close_zero_linger (dealer);
+    close_zero_linger (stream);
+    zmq_ctx_term (ctx);
+}


### PR DESCRIPTION
backport of zeromq/libzmq#721

In the discussion, it was decided to backport, but that never actually happened.

test file was renamed after the above PR, so the version from master is pulled in here.