### PR TITLE
Problem: shutdown asserts if WSASTARUP wasn't done previously

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,8 @@
 
 * Fixed #1362 - SUB socket sometimes fails to resubscribe properly.
 
+* Fixed #1377, #1144 - failed with WSANOTINITIALISED in some cases.
+
 
 0MQ version 4.0.5 stable, released on 2014/10/14
 ================================================

--- a/src/signaler.cpp
+++ b/src/signaler.cpp
@@ -146,12 +146,15 @@ zmq::signaler_t::~signaler_t ()
 #elif defined ZMQ_HAVE_WINDOWS
     struct linger so_linger = { 1, 0 };
     int rc = setsockopt (w, SOL_SOCKET, SO_LINGER,
-        (char *)&so_linger, sizeof (so_linger));
-    wsa_assert (rc != SOCKET_ERROR);
-    rc = closesocket (w);
-    wsa_assert (rc != SOCKET_ERROR);
-    rc = closesocket (r);
-    wsa_assert (rc != SOCKET_ERROR);
+        (const char *) &so_linger, sizeof so_linger);
+    //  Only check shutdown if WSASTARTUP was previously done
+    if (rc == 0 || WSAGetLastError () != WSANOTINITIALISED) {
+        wsa_assert (rc != SOCKET_ERROR);
+        rc = closesocket (w);
+        wsa_assert (rc != SOCKET_ERROR);
+        rc = closesocket (r);
+        wsa_assert (rc != SOCKET_ERROR);
+    }
 #else
     int rc = close_wait_ms (w);
     errno_assert (rc == 0);


### PR DESCRIPTION
This is a silly assertion that causes problems if libzmq.dll is
called in some esoteric ways.

Solution: if the shutdown code detects WSANOTINITIALISED, then
exit silently.

Fixes #1377
Fixes #1144

Conflicts:

	src/signaler.cpp