### PR TITLE
Travis ci osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,10 @@ before_script:
 - if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi
 - cd ..
 
+# ZMQ stress tests need more open socket (files) than the usual default
+# On OSX, it seems the way to set the max files limit is constantly changing, so
+# try to use all known knobs to ensure compatibility across various versions
+- if [ $TRAVIS_OS_NAME == "osx" ] ; then sudo sysctl -w kern.maxfiles=64000 ; sudo sysctl -w kern.maxfilesperproc=64000 ; sudo launchctl limit maxfiles 64000 64000 ; fi ; ulimit -n 64000
+
 #   Build and check libzmq
 script: ./autogen.sh && ./configure && make V=1 && make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
 - ./autogen.sh
 - ./configure && make check
 - sudo make install
-- sudo ldconfig
+- if [ $TRAVIS_OS_NAME != "osx" ] ; then sudo ldconfig ; fi
 - cd ..
 
 #   Build and check libzmq

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 
 language: c
 
+os:
+- linux
+- osx
+
 #   Build required projects first
 before_script:
 


### PR DESCRIPTION
This PR makes the CI build scripts compatible with OSX on Travis. Fixes #133. Note that until OSX build is enabled on a project by emailing support@travis-ci.com, the option in travis.yml will have no effect.