### PR TITLE
Problem: CI may fail due to timeout. Fixes #135

### DIFF
--- a/tests/test_immediate.cpp
+++ b/tests/test_immediate.cpp
@@ -66,7 +66,7 @@ int main (void)
 
     // We now consume from the connected pipe
     // - we should see just 5
-    int timeout = 100;
+    int timeout = 250;
     rc = zmq_setsockopt (to, ZMQ_RCVTIMEO, &timeout, sizeof (int));
     assert (rc == 0);
 

--- a/tests/test_req_relaxed.cpp
+++ b/tests/test_req_relaxed.cpp
@@ -44,7 +44,7 @@ int main (void)
         rep [peer] = zmq_socket (ctx, ZMQ_REP);
         assert (rep [peer]);
 
-        int timeout = 100;
+        int timeout = 250;
         rc = zmq_setsockopt (rep [peer], ZMQ_RCVTIMEO, &timeout, sizeof (int));
         assert (rc == 0);
 

--- a/tests/test_security_curve.cpp
+++ b/tests/test_security_curve.cpp
@@ -244,7 +244,7 @@ int main (void)
     send (s, "\x01\x00", 2, 0);
     // send sneaky message that shouldn't be received
     send (s, "\x08\x00sneaky\0", 9, 0);
-    int timeout = 150;
+    int timeout = 250;
     zmq_setsockopt (server, ZMQ_RCVTIMEO, &timeout, sizeof (timeout));
     char *buf = s_recv (server);
     if (buf != NULL) {

--- a/tests/test_security_null.cpp
+++ b/tests/test_security_null.cpp
@@ -157,7 +157,7 @@ int main (void)
     send (s, "\x01\x00", 2, 0);
     // send sneaky message that shouldn't be received
     send (s, "\x08\x00sneaky\0", 9, 0);
-    int timeout = 150;
+    int timeout = 250;
     zmq_setsockopt (server, ZMQ_RCVTIMEO, &timeout, sizeof (timeout));
     char *buf = s_recv (server);
     if (buf != NULL) {

--- a/tests/test_security_plain.cpp
+++ b/tests/test_security_plain.cpp
@@ -163,7 +163,7 @@ int main (void)
     send (s, "\x01\x00", 2, 0);
     // send sneaky message that shouldn't be received
     send (s, "\x08\x00sneaky\0", 9, 0);
-    int timeout = 150;
+    int timeout = 250;
     zmq_setsockopt (server, ZMQ_RCVTIMEO, &timeout, sizeof (timeout));
     char *buf = s_recv (server);
     if (buf != NULL) {

--- a/tests/test_spec_dealer.cpp
+++ b/tests/test_spec_dealer.cpp
@@ -36,7 +36,7 @@ void test_round_robin_out (void *ctx)
         rep [peer] = zmq_socket (ctx, ZMQ_REP);
         assert (rep [peer]);
 
-        int timeout = 100;
+        int timeout = 250;
         rc = zmq_setsockopt (rep [peer], ZMQ_RCVTIMEO, &timeout, sizeof (int));
         assert (rc == 0);
 
@@ -77,7 +77,7 @@ void test_fair_queue_in (void *ctx)
     void *receiver = zmq_socket (ctx, ZMQ_DEALER);
     assert (receiver);
 
-    int timeout = 100;
+    int timeout = 250;
     int rc = zmq_setsockopt (receiver, ZMQ_RCVTIMEO, &timeout, sizeof (int));
     assert (rc == 0);
 
@@ -200,7 +200,7 @@ void test_block_on_send_no_peers (void *ctx)
     void *sc = zmq_socket (ctx, ZMQ_DEALER);
     assert (sc);
 
-    int timeout = 100;
+    int timeout = 250;
     int rc = zmq_setsockopt (sc, ZMQ_SNDTIMEO, &timeout, sizeof (timeout));
     assert (rc == 0);
 

--- a/tests/test_spec_pushpull.cpp
+++ b/tests/test_spec_pushpull.cpp
@@ -36,7 +36,7 @@ void test_push_round_robin_out (void *ctx)
         pulls [peer] = zmq_socket (ctx, ZMQ_PULL);
         assert (pulls [peer]);
 
-        int timeout = 100;
+        int timeout = 250;
         rc = zmq_setsockopt (pulls [peer], ZMQ_RCVTIMEO, &timeout, sizeof (int));
         assert (rc == 0);
 
@@ -155,7 +155,7 @@ void test_push_block_on_send_no_peers (void *ctx)
     void *sc = zmq_socket (ctx, ZMQ_PUSH);
     assert (sc);
 
-    int timeout = 100;
+    int timeout = 250;
     int rc = zmq_setsockopt (sc, ZMQ_SNDTIMEO, &timeout, sizeof (timeout));
     assert (rc == 0);
 

--- a/tests/test_spec_rep.cpp
+++ b/tests/test_spec_rep.cpp
@@ -27,7 +27,7 @@ void test_fair_queue_in (void *ctx)
     void *rep = zmq_socket (ctx, ZMQ_REP);
     assert (rep);
 
-    int timeout = 100;
+    int timeout = 250;
     int rc = zmq_setsockopt (rep, ZMQ_RCVTIMEO, &timeout, sizeof (int));
     assert (rc == 0);
 

--- a/tests/test_spec_req.cpp
+++ b/tests/test_spec_req.cpp
@@ -36,7 +36,7 @@ void test_round_robin_out (void *ctx)
         rep [peer] = zmq_socket (ctx, ZMQ_REP);
         assert (rep [peer]);
 
-        int timeout = 100;
+        int timeout = 250;
         rc = zmq_setsockopt (rep [peer], ZMQ_RCVTIMEO, &timeout, sizeof (int));
         assert (rc == 0);
 
@@ -83,7 +83,7 @@ void test_req_only_listens_to_current_peer (void *ctx)
         router [i] = zmq_socket (ctx, ZMQ_ROUTER);
         assert (router [i]);
 
-        int timeout = 100;
+        int timeout = 250;
         rc = zmq_setsockopt (router [i], ZMQ_RCVTIMEO, &timeout, sizeof (timeout));
         assert (rc == 0);
 
@@ -195,7 +195,7 @@ void test_block_on_send_no_peers (void *ctx)
     void *sc = zmq_socket (ctx, ZMQ_REQ);
     assert (sc);
 
-    int timeout = 100;
+    int timeout = 250;
     int rc = zmq_setsockopt (sc, ZMQ_SNDTIMEO, &timeout, sizeof (timeout));
     assert (rc == 0);
 

--- a/tests/test_spec_router.cpp
+++ b/tests/test_spec_router.cpp
@@ -27,7 +27,7 @@ void test_fair_queue_in (void *ctx)
     void *receiver = zmq_socket (ctx, ZMQ_ROUTER);
     assert (receiver);
 
-    int timeout = 100;
+    int timeout = 250;
     int rc = zmq_setsockopt (receiver, ZMQ_RCVTIMEO, &timeout, sizeof (int));
     assert (rc == 0);
 

--- a/tests/testutil.hpp
+++ b/tests/testutil.hpp
@@ -112,7 +112,7 @@ expect_bounce_fail (void *server, void *client)
     const char *content = "12345678ABCDEFGH12345678abcdefgh";
     char buffer [32];
 
-    int timeout = 150;
+    int timeout = 250;
     int rc;
     rc = zmq_setsockopt (client, ZMQ_SNDTIMEO, &timeout, sizeof (int));
     assert (rc == 0);


### PR DESCRIPTION
Solution: cherry-pick Pieter Hintjens commit a7a512ab from libzmq
repository to increase test timeouts to 250 msec.

Cherry-picked from: https://github.com/zeromq/libzmq/commit/a7a512ab