### PR TITLE
Problem: curve keys getsockopt uninitialised read

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
 
 - mkdir tmp
 #   libsodium
-- git clone git://github.com/jedisct1/libsodium.git
+- git clone --depth 1 -b stable git://github.com/jedisct1/libsodium.git
 - ( cd libsodium; ./autogen.sh; ./configure --prefix=${BUILD_PREFIX}; make check; make install )
 
 # ZMQ stress tests need more open socket (files) than the usual default

--- a/AUTHORS
+++ b/AUTHORS
@@ -53,6 +53,7 @@ Joe Thornber <joe.thornber@gmail.com>
 Jon Dyte <jon@totient.co.uk>
 Kamil Shakirov <kamils80@gmail.com>
 Ken Steele <ken@tilera.com>
+Luca Boccassi <luca.boccassi@gmail.com>
 Marc Rossi <mrossi19@gmail.com>
 Martin Hurton <hurtonm@gmail.com>
 Martin Lucina <martin@lucina.net>

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@
 
 * Fixed LIBZMQ-949 - zmq_unbind fails for inproc and wildcard endpoints
 
+* Fixed #1806 - uninitialised read in curve getsockopt.
+
+* Fixed #1807 - build broken with GCC 6.
+
 
 0MQ version 4.0.7 stable, released on 2015/06/15
 ================================================

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -55,6 +55,9 @@ zmq::options_t::options_t () :
     socket_id (0),
     conflate (false)
 {
+    memset (curve_public_key, 0, CURVE_KEYSIZE);
+    memset (curve_secret_key, 0, CURVE_KEYSIZE);
+    memset (curve_server_key, 0, CURVE_KEYSIZE);
 }
 
 int zmq::options_t::setsockopt (int option_, const void *optval_,


### PR DESCRIPTION
Solution: backport from https://github.com/zeromq/libzmq/pull/1805 together with a small fix for Travis CI.
Also update NEWS and AUTHORS.