### PR TITLE
Problem: zmq_bind IPv4 fallback still tries IPv6

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,8 @@
 
 * Fixed #1877 - Avoid terminating connections prematurely
 
+* Fixed #1887 - zmq_bind IPv4 fallback still tries IPv6
+
 
 0MQ version 4.0.7 stable, released on 2015/06/15
 ================================================

--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -209,6 +209,18 @@ int zmq::tcp_connecter_t::open ()
 
     //  Create the socket.
     s = open_socket (addr->resolved.tcp_addr->family (), SOCK_STREAM, IPPROTO_TCP);
+
+    //  IPv6 address family not supported, try automatic downgrade to IPv4.
+    if (s == -1 && addr->resolved.tcp_addr->family () == AF_INET6
+    && errno == EAFNOSUPPORT
+    && options.ipv6) {
+        int rc = addr->resolved.tcp_addr->resolve (
+            addr->address.c_str (), false, false);
+        if (rc != 0)
+            return -1;
+        s = open_socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    }
+
 #ifdef ZMQ_HAVE_WINDOWS
     if (s == INVALID_SOCKET) {
         errno = wsa_error_to_errno (WSAGetLastError ());

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -159,13 +159,13 @@ int zmq::tcp_listener_t::set_address (const char *addr_)
 #endif
 
     //  IPv6 address family not supported, try automatic downgrade to IPv4.
-    if (address.family () == AF_INET6
+    if (s == -1 && address.family () == AF_INET6
     && errno == EAFNOSUPPORT
     && options.ipv6) {
-        rc = address.resolve (addr_, true, true);
+        rc = address.resolve (addr_, true, false);
         if (rc != 0)
             return rc;
-        s = ::socket (address.family (), SOCK_STREAM, IPPROTO_TCP);
+        s = open_socket (AF_INET, SOCK_STREAM, IPPROTO_TCP);
     }
 
 #ifdef ZMQ_HAVE_WINDOWS

--- a/src/tcp_listener.cpp
+++ b/src/tcp_listener.cpp
@@ -153,10 +153,6 @@ int zmq::tcp_listener_t::set_address (const char *addr_)
 
     //  Create a listening socket.
     s = open_socket (address.family (), SOCK_STREAM, IPPROTO_TCP);
-#ifdef ZMQ_HAVE_WINDOWS
-    if (s == INVALID_SOCKET)
-        errno = wsa_error_to_errno (WSAGetLastError ());
-#endif
 
     //  IPv6 address family not supported, try automatic downgrade to IPv4.
     if (s == -1 && address.family () == AF_INET6


### PR DESCRIPTION
Solution: backport fix from https://github.com/zeromq/libzmq/pull/1888
Fixes https://github.com/zeromq/libzmq/issues/1887