### PR TITLE
Problem: tempnam is deprecated and insecure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ autom4te.cache
 .*~
 tools/curve_keygen.o
 tools/curve_keygen
+tests/test_ipc_wildcard
 tests/test_issue_566
 tests/test_ctx_destroy
 tests/test_term_endpoint

--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,8 @@
 
 * Fixed #919 - ZMQ_LINGER (related to #1877)
 
+* Fixed #139 - "tempnam" is deprecated.
+
 
 0MQ version 4.0.7 stable, released on 2015/06/15
 ================================================

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -125,9 +125,11 @@ int zmq::ipc_listener_t::set_address (const char *addr_)
     //  Allow wildcard file
     if (addr [0] == '*') {
         char buffer [12] = "2134XXXXXX";
-        if (mkstemp (buffer) == -1)
+        int fd = mkstemp (buffer);
+        if (fd == -1)
             return -1;
         addr.assign (buffer);
+        ::close (fd);
     }
 
     //  Get rid of the file associated with the UNIX domain socket that

--- a/src/ipc_listener.cpp
+++ b/src/ipc_listener.cpp
@@ -123,10 +123,11 @@ int zmq::ipc_listener_t::set_address (const char *addr_)
     std::string addr (addr_);
 
     //  Allow wildcard file
-    if (addr[0] == '*') {
-        char *tmpstr = tempnam (NULL, NULL);
-        addr.assign (tmpstr);
-        free (tmpstr);
+    if (addr [0] == '*') {
+        char buffer [12] = "2134XXXXXX";
+        if (mkstemp (buffer) == -1)
+            return -1;
+        addr.assign (buffer);
     }
 
     //  Get rid of the file associated with the UNIX domain socket that

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -45,6 +45,7 @@ noinst_PROGRAMS = test_system \
                   test_proxy_single_socket \
                   test_proxy_terminate \
                   test_many_sockets \
+                  test_ipc_wildcard \
                   test_stream_empty
 
 if !ON_MINGW
@@ -95,6 +96,7 @@ test_inproc_connect_SOURCES = test_inproc_connect.cpp
 test_issue_566_SOURCES = test_issue_566.cpp
 test_abstract_ipc_SOURCES = test_abstract_ipc.cpp
 test_many_sockets_SOURCES = test_many_sockets.cpp
+test_ipc_wildcard_SOURCES = test_ipc_wildcard.cpp
 test_proxy_single_socket_SOURCES = test_proxy_single_socket.cpp
 test_proxy_terminate_SOURCES = test_proxy_terminate.cpp
 test_stream_empty_SOURCES = test_stream_empty.cpp

--- a/tests/test_ipc_wildcard.cpp
+++ b/tests/test_ipc_wildcard.cpp
@@ -1,0 +1,55 @@
+/*
+    Copyright (c) 2007-2013 Contributors as noted in the AUTHORS file
+
+    This file is part of 0MQ.
+
+    0MQ is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    0MQ is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "testutil.hpp"
+
+int main (void)
+{
+    setup_test_environment();
+    void *ctx = zmq_ctx_new ();
+    assert (ctx);
+
+    void *sb = zmq_socket (ctx, ZMQ_PAIR);
+    assert (sb);
+    int rc = zmq_bind (sb, "ipc://*");
+    assert (rc == 0);
+
+    char endpoint [200];
+    size_t size = sizeof (endpoint);
+    rc = zmq_getsockopt (sb, ZMQ_LAST_ENDPOINT, endpoint, &size);
+    assert (rc == 0);
+
+    void *sc = zmq_socket (ctx, ZMQ_PAIR);
+    assert (sc);
+    rc = zmq_connect (sc, endpoint);
+    assert (rc == 0);
+    
+    bounce (sb, sc);
+
+    rc = zmq_close (sc);
+    assert (rc == 0);
+
+    rc = zmq_close (sb);
+    assert (rc == 0);
+
+    rc = zmq_ctx_term (ctx);
+    assert (rc == 0);
+
+    return 0 ;
+}


### PR DESCRIPTION
Solution: backport commits to use mkstemp from libzmq

Fixes https://github.com/zeromq/zeromq4-x/issues/139